### PR TITLE
Fix warnings when "openssl" feature is off

### DIFF
--- a/tests/certs.rs
+++ b/tests/certs.rs
@@ -3,12 +3,12 @@
 mod naples;
 mod rome;
 
-use ::sev::certs::*;
-use codicon::Decoder;
-
 #[test]
 #[cfg(feature = "openssl")]
 fn test_for_verify_false_positive() {
+    use ::sev::certs::*;
+    use codicon::Decoder;
+
     // https://github.com/enarx/enarx/issues/520
     let naples_cek = sev::Certificate::decode(&mut &naples::CEK[..], ()).unwrap();
     let rome_ask = ca::Certificate::decode(&mut &builtin::rome::ASK[..], ()).unwrap();

--- a/tests/naples/cek.rs
+++ b/tests/naples/cek.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use ::sev::certs::builtin::naples::ASK;
 
 #[test]
 fn decode() {
@@ -21,6 +20,8 @@ fn encode() {
 #[cfg(feature = "openssl")]
 #[test]
 fn verify() {
+    use ::sev::certs::builtin::naples::ASK;
+
     let ask = ca::Certificate::decode(&mut ASK, ()).unwrap();
     let cek = sev::Certificate::decode(&mut CEK, ()).unwrap();
 

--- a/tests/rome/cek.rs
+++ b/tests/rome/cek.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use ::sev::certs::builtin::rome::ASK;
 
 #[test]
 fn decode() {
@@ -21,6 +20,8 @@ fn encode() {
 #[cfg(feature = "openssl")]
 #[test]
 fn verify() {
+    use ::sev::certs::builtin::rome::ASK;
+
     let ask = ca::Certificate::decode(&mut ASK, ()).unwrap();
     let cek = sev::Certificate::decode(&mut CEK, ()).unwrap();
 


### PR DESCRIPTION
Just move these imports into the conditionally compiled blocks that use
them. They're the only consumers.