### PR TITLE
Make hardware test execution control more granular

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.profile.flag }} --features=dangerous_tests,${{ matrix.features }}
+          args: ${{ matrix.profile.flag }} --features=dangerous_hw_tests,${{ matrix.features }}
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,8 @@ is-it-maintained-open-issues = { repository = "enarx/sev" }
 
 [features]
 default = []
-dangerous_hw_tests = []
+hw_tests = []
+dangerous_hw_tests = ["hw_tests"]
 
 [dependencies]
 openssl = { version = "0.10", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ is-it-maintained-open-issues = { repository = "enarx/sev" }
 
 [features]
 default = []
-dangerous_tests = []
+dangerous_hw_tests = []
 
 [dependencies]
 openssl = { version = "0.10", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,7 @@
 fn main() {
     use std::path::Path;
 
-    if Path::new("/dev/sev").exists() {
+    if cfg!(feature = "hw_tests") || Path::new("/dev/sev").exists() {
         println!("cargo:rustc-cfg=has_sev");
     }
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -15,7 +15,7 @@ fn rm_cached_chain() {
     }
 }
 
-#[cfg_attr(not(all(has_sev, feature = "dangerous_tests")), ignore)]
+#[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
 #[test]
 #[serial]
 fn platform_reset() {
@@ -41,7 +41,7 @@ fn platform_status() {
     );
 }
 
-#[cfg_attr(not(all(has_sev, feature = "dangerous_tests")), ignore)]
+#[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
 #[test]
 #[serial]
 fn pek_generate() {
@@ -58,7 +58,7 @@ fn pek_csr() {
     assert_eq!(pek, Usage::PEK);
 }
 
-#[cfg_attr(not(all(has_sev, feature = "dangerous_tests")), ignore)]
+#[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
 #[test]
 #[serial]
 fn pdh_generate() {
@@ -85,7 +85,7 @@ fn pdh_cert_export() {
 }
 
 #[cfg(feature = "openssl")]
-#[cfg_attr(not(all(has_sev, feature = "dangerous_tests")), ignore)]
+#[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
 #[test]
 #[serial]
 fn pek_cert_import() {


### PR DESCRIPTION
Closes #3.

- Rename dangerous_tests to dangerous_hw_tests
- Make hardware test execution control more granular

When /dev/sev does not exist:

Autodetection:

    $ cargo test
    [..]
    test get_identifer ... ignored
    test pdh_generate ... ignored
    test pek_csr ... ignored
    test pek_generate ... ignored
    test platform_reset ... ignored
    test platform_status ... ignored
    [..]

Override:

    $ cargo test --features=hw_tests
    [..]
    test pdh_generate ... ignored
    test pek_generate ... ignored
    test platform_reset ... ignored
    test pek_csr ... FAILED
    test get_identifer ... FAILED
    test platform_status ... FAILED
    [..]

With dangerous tests:

    $ cargo test --features=dangerous_hw_tests
    [..]
    test get_identifer ... FAILED
    test pek_csr ... FAILED
    test platform_status ... FAILED
    test pdh_generate ... FAILED
    test pek_generate ... FAILED
    test platform_reset ... FAILED
    [..]

When /dev/sev DOES exist:

    $ cargo test
    [..]
    test pdh_generate ... ignored
    test pek_generate ... ignored
    test platform_reset ... ignored
    test get_identifer ... ok
    test pek_csr ... ok
    test platform_status ... ok
    [..]

Override:

    $ cargo test --features=hw_tests
    [..]
    test pdh_generate ... ignored
    test pek_generate ... ignored
    test platform_reset ... ignored
    test get_identifer ... ok
    test pek_csr ... ok
    test platform_status ... ok
    [..]

With dangerous tests:

    $ cargo test --features=dangerous_hw_tests
    [..]
    test get_identifer ... ok
    test platform_status ... ok
    test pek_csr ... ok
    test pdh_generate ... ok
    test platform_reset ... ok
    test pek_generate ... ok
    [..]