### PR TITLE
Add binary blob (de)serialization for attestation types

### DIFF
--- a/src/certs/mod.rs
+++ b/src/certs/mod.rs
@@ -6,6 +6,7 @@ pub mod builtin;
 pub mod ca;
 mod chain;
 pub mod sev;
+#[cfg(feature = "openssl")]
 mod util;
 
 #[cfg(feature = "openssl")]
@@ -16,7 +17,8 @@ use std::io::*;
 
 pub use chain::Chain;
 
-#[allow(unused_imports)]
+use crate::util::*;
+#[cfg(feature = "openssl")]
 use util::*;
 
 #[cfg(feature = "openssl")]

--- a/src/certs/util.rs
+++ b/src/certs/util.rs
@@ -1,20 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use super::*;
-use std::mem::{size_of, MaybeUninit};
-use std::slice::{from_raw_parts, from_raw_parts_mut};
+use std::io::Result;
 
-#[cfg(feature = "openssl")]
 pub trait FromLe: Sized {
     fn from_le(value: &[u8]) -> Result<Self>;
 }
 
-#[cfg(feature = "openssl")]
 pub trait IntoLe<T> {
     fn into_le(&self) -> T;
 }
 
-#[cfg(feature = "openssl")]
 impl FromLe for openssl::bn::BigNum {
     #[inline]
     fn from_le(value: &[u8]) -> Result<Self> {
@@ -24,7 +19,6 @@ impl FromLe for openssl::bn::BigNum {
     }
 }
 
-#[cfg(feature = "openssl")]
 impl IntoLe<[u8; 72]> for openssl::bn::BigNumRef {
     fn into_le(&self) -> [u8; 72] {
         let mut buf = [0u8; 72];
@@ -37,7 +31,6 @@ impl IntoLe<[u8; 72]> for openssl::bn::BigNumRef {
     }
 }
 
-#[cfg(feature = "openssl")]
 impl IntoLe<[u8; 512]> for openssl::bn::BigNumRef {
     fn into_le(&self) -> [u8; 512] {
         let mut buf = [0u8; 512];
@@ -49,25 +42,3 @@ impl IntoLe<[u8; 512]> for openssl::bn::BigNumRef {
         buf
     }
 }
-
-pub trait TypeLoad: Read {
-    fn load<T: Sized + Copy>(&mut self) -> Result<T> {
-        #[allow(clippy::uninit_assumed_init)]
-        let mut t = unsafe { MaybeUninit::uninit().assume_init() };
-        let p = &mut t as *mut T as *mut u8;
-        let s = unsafe { from_raw_parts_mut(p, size_of::<T>()) };
-        self.read_exact(s)?;
-        Ok(t)
-    }
-}
-
-pub trait TypeSave: Write {
-    fn save<T: Sized + Copy>(&mut self, value: &T) -> Result<()> {
-        let p = value as *const T as *const u8;
-        let s = unsafe { from_raw_parts(p, size_of::<T>()) };
-        self.write_all(s)
-    }
-}
-
-impl<T: Read> TypeLoad for T {}
-impl<T: Write> TypeSave for T {}

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -79,7 +79,8 @@ pub struct Session {
 }
 
 /// Used to establish a secure session with the AMD SP.
-#[derive(Debug, PartialEq, Eq)]
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Start {
     /// The tenant's policy for this SEV guest.
     pub policy: Policy,
@@ -89,6 +90,22 @@ pub struct Start {
 
     /// A secure channel with the AMD SP.
     pub session: Session,
+}
+
+impl codicon::Decoder<()> for Start {
+    type Error = std::io::Error;
+
+    fn decode(mut reader: impl Read, _: ()) -> std::io::Result<Self> {
+        reader.load()
+    }
+}
+
+impl codicon::Encoder<()> for Start {
+    type Error = std::io::Error;
+
+    fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {
+        writer.save(self)
+    }
 }
 
 bitflags! {

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -145,6 +145,26 @@ pub struct Secret {
     pub ciphertext: Vec<u8>,
 }
 
+impl codicon::Decoder<()> for Secret {
+    type Error = std::io::Error;
+
+    fn decode(mut reader: impl Read, _: ()) -> std::io::Result<Self> {
+        let header = reader.load()?;
+        let mut ciphertext = vec![];
+        let _ = reader.read_to_end(&mut ciphertext)?;
+        Ok(Self { header, ciphertext })
+    }
+}
+
+impl codicon::Encoder<()> for Secret {
+    type Error = std::io::Error;
+
+    fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {
+        writer.save(&self.header)?;
+        writer.write_all(&self.ciphertext)
+    }
+}
+
 /// A measurement of the SEV guest.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -155,3 +155,19 @@ pub struct Measurement {
     /// A random nonce.
     pub mnonce: [u8; 16],
 }
+
+impl codicon::Decoder<()> for Measurement {
+    type Error = std::io::Error;
+
+    fn decode(mut reader: impl Read, _: ()) -> std::io::Result<Self> {
+        reader.load()
+    }
+}
+
+impl codicon::Encoder<()> for Measurement {
+    type Error = std::io::Error;
+
+    fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {
+        writer.save(self)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod session;
 mod util;
 
 pub use util::cached_chain;
+use util::{TypeLoad, TypeSave};
 
 #[cfg(feature = "openssl")]
 use certs::sev;
@@ -53,6 +54,7 @@ use certs::{builtin, ca};
 
 #[cfg(feature = "openssl")]
 use std::convert::TryFrom;
+use std::io::{Read, Write};
 
 /// Information about the SEV platform version.
 #[repr(C)]
@@ -85,6 +87,22 @@ pub struct Build {
 impl std::fmt::Display for Build {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}.{}", self.version, self.build)
+    }
+}
+
+impl codicon::Decoder<()> for Build {
+    type Error = std::io::Error;
+
+    fn decode(mut reader: impl Read, _: ()) -> std::io::Result<Self> {
+        reader.load()
+    }
+}
+
+impl codicon::Encoder<()> for Build {
+    type Error = std::io::Error;
+
+    fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {
+        writer.save(self)
     }
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -4,3 +4,29 @@
 
 pub mod cached_chain;
 mod impl_const_id;
+
+use std::io::{Read, Result, Write};
+use std::mem::{size_of, MaybeUninit};
+use std::slice::{from_raw_parts, from_raw_parts_mut};
+
+pub trait TypeLoad: Read {
+    fn load<T: Sized + Copy>(&mut self) -> Result<T> {
+        #[allow(clippy::uninit_assumed_init)]
+        let mut t = unsafe { MaybeUninit::uninit().assume_init() };
+        let p = &mut t as *mut T as *mut u8;
+        let s = unsafe { from_raw_parts_mut(p, size_of::<T>()) };
+        self.read_exact(s)?;
+        Ok(t)
+    }
+}
+
+pub trait TypeSave: Write {
+    fn save<T: Sized + Copy>(&mut self, value: &T) -> Result<()> {
+        let p = value as *const T as *const u8;
+        let s = unsafe { from_raw_parts(p, size_of::<T>()) };
+        self.write_all(s)
+    }
+}
+
+impl<T: Read> TypeLoad for T {}
+impl<T: Write> TypeSave for T {}


### PR DESCRIPTION
The [remote AMD SEV protocol attestation message types](https://github.com/enarx/koine/pull/9) allow the payload types to be transmitted as a CBOR-encoded structure _or_ a binary blob whose characteristics match that of a little-endian x86_64 machine.

This pull request enables support for the binary blob encoding for the remaining relevant types. A subsequent pull request will enable serde (in our case: CBOR)-encoding for these types to enable serde support.

- Move Type{Load,Save} helper traits into crate-wide utils
- impl {De,En}coder for Build
- impl {De,En}coder for launch::Start
- impl {De,En}coder for Measurement
- impl {De,En}coder for Secret

Related: https://github.com/enarx/enarx/issues/906