### PR TITLE
Replace u128s with equivalent byte array representations

### DIFF
--- a/src/certs/ca/cert/v1.rs
+++ b/src/certs/ca/cert/v1.rs
@@ -9,10 +9,10 @@ const NAPLES_ARK_SIG: &[u8] = include_bytes!("../../../../tests/naples/ark.cert.
 const NAPLES_ARK: Preamble = Preamble {
     ver: 1u32.to_le(),
     data: Data {
-        kid: 122178821951678173525318614033703090459u128.to_le(),
-        sid: 122178821951678173525318614033703090459u128.to_le(),
+        kid: *b"\x1b\xb9\x87\xc3\x59\x49\x46\x06\xb1\x74\x94\x56\x01\xc9\xea\x5b",
+        sid: *b"\x1b\xb9\x87\xc3\x59\x49\x46\x06\xb1\x74\x94\x56\x01\xc9\xea\x5b",
         usage: Usage::ARK,
-        reserved: 0,
+        reserved: [0; 16],
         psize: 2048u32.to_le(),
         msize: 2048u32.to_le(),
     },
@@ -36,10 +36,10 @@ impl Into<hash::MessageDigest> for Size {
 #[repr(C, packed)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Data {
-    pub kid: u128,
-    pub sid: u128,
+    pub kid: [u8; 16],
+    pub sid: [u8; 16],
     pub usage: Usage,
-    pub reserved: u128,
+    pub reserved: [u8; 16],
     pub psize: u32,
     pub msize: u32,
 }

--- a/src/certs/mod.rs
+++ b/src/certs/mod.rs
@@ -50,7 +50,7 @@ pub trait Signer<T> {
 
 #[cfg(feature = "openssl")]
 struct Signature {
-    id: Option<u128>,
+    id: Option<[u8; 16]>,
     sig: Vec<u8>,
     kind: pkey::Id,
     hash: hash::MessageDigest,
@@ -60,7 +60,7 @@ struct Signature {
 #[cfg(feature = "openssl")]
 /// Represents a private key.
 pub struct PrivateKey<U> {
-    id: Option<u128>,
+    id: Option<[u8; 16]>,
     key: pkey::PKey<pkey::Private>,
     hash: hash::MessageDigest,
     usage: U,
@@ -68,7 +68,7 @@ pub struct PrivateKey<U> {
 
 #[cfg(feature = "openssl")]
 struct PublicKey<U> {
-    id: Option<u128>,
+    id: Option<[u8; 16]>,
     key: pkey::PKey<pkey::Public>,
     hash: hash::MessageDigest,
     usage: U,


### PR DESCRIPTION
u128s are not supported in the serde frameworks we intend to use,
so represent them as an equivalent array type (which ARE) supported.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>

Closes #27 
