### PR TITLE
Disable dangerous tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: test
-          args: ${{ matrix.profile.flag }} --features=dangerous_hw_tests,${{ matrix.features }}
+          args: ${{ matrix.profile.flag }} --features=${{ matrix.features }}
     strategy:
       fail-fast: false
       matrix:
@@ -54,3 +54,4 @@ jobs:
         features:
           -
           - openssl
+          - hw_tests

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -16,6 +16,7 @@ fn rm_cached_chain() {
 }
 
 #[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
+#[ignore]
 #[test]
 #[serial]
 fn platform_reset() {
@@ -42,6 +43,7 @@ fn platform_status() {
 }
 
 #[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
+#[ignore]
 #[test]
 #[serial]
 fn pek_generate() {
@@ -59,6 +61,7 @@ fn pek_csr() {
 }
 
 #[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
+#[ignore]
 #[test]
 #[serial]
 fn pdh_generate() {
@@ -86,6 +89,7 @@ fn pdh_cert_export() {
 
 #[cfg(feature = "openssl")]
 #[cfg_attr(not(all(has_sev, feature = "dangerous_hw_tests")), ignore)]
+#[ignore]
 #[test]
 #[serial]
 fn pek_cert_import() {


### PR DESCRIPTION
- Don't run dangerous tests as part of CI
- Unconditionally disable dangerous_hw_tests
