### PR TITLE
Add serde support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ dangerous_hw_tests = ["hw_tests"]
 
 [dependencies]
 openssl = { version = "0.10", optional = true }
+serde = { version = "1.0", features = ["derive"] }
 bitflags = "1.2"
 codicon = "3.0"
 bitfield = "0.13"

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -14,10 +14,11 @@ pub use launcher::Launcher;
 
 use super::*;
 use bitflags::bitflags;
+use serde::{Deserialize, Serialize};
 
 bitflags! {
     /// Configurable SEV Policy options.
-    #[derive(Default)]
+    #[derive(Default, Deserialize, Serialize)]
     pub struct PolicyFlags: u16 {
         /// When set, debugging the guest is forbidden.
         const NO_DEBUG        = 0b00000001u16.to_le();
@@ -44,7 +45,7 @@ bitflags! {
 /// Describes a policy that the AMD Secure Processor will
 /// enforce.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Policy {
     /// The various policy optons are encoded as bit flags.
     pub flags: PolicyFlags,
@@ -56,7 +57,7 @@ pub struct Policy {
 /// A secure channel between the tenant and the AMD Secure
 /// Processor.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Session {
     /// Used for deriving a shared secret between the tenant
     /// and the AMD SP.
@@ -110,7 +111,7 @@ impl codicon::Encoder<()> for Start {
 
 bitflags! {
     /// Additional descriptions of the secret header packet.
-    #[derive(Default)]
+    #[derive(Default, Deserialize, Serialize)]
     pub struct HeaderFlags: u32 {
         /// If set, the contents of the packet are compressed and
         /// the AMD SP must decompress them.
@@ -121,7 +122,7 @@ bitflags! {
 /// The header for a data packet that contains secret information
 /// to be injected into the guest.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Header {
     /// Describes the secret packet (for example: if it is
     /// compressed).
@@ -136,7 +137,7 @@ pub struct Header {
 
 /// A packet containing secret information to be injected
 /// into the guest.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Secret {
     /// The header for this packet.
     pub header: Header,
@@ -167,7 +168,7 @@ impl codicon::Encoder<()> for Secret {
 
 /// A measurement of the SEV guest.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct Measurement {
     /// The measurement.
     pub measure: [u8; 32],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,13 +52,15 @@ use util::{TypeLoad, TypeSave};
 use certs::sev;
 use certs::{builtin, ca};
 
+use serde::{Deserialize, Serialize};
+
 #[cfg(feature = "openssl")]
 use std::convert::TryFrom;
 use std::io::{Read, Write};
 
 /// Information about the SEV platform version.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Version {
     /// The major version number.
     pub major: u8,
@@ -75,7 +77,7 @@ impl std::fmt::Display for Version {
 
 /// A description of the SEV platform's build information.
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct Build {
     /// The version information.
     pub version: Version,


### PR DESCRIPTION
Derive serde support for relevant attestation types (_except certificates_)

Reasoning pasted from another PR: 

> NOTE: it's CBOR-encoding all the way down, now, forget about the two modes of encoding (CBOR or opaque blob). I flew too close to the sun. The only exception is the certificate payloads. These are blobs. Their structure is well-defined in the AMD spec and it is ironically more work for a client not using our tooling to encode them as CBOR than it would be for them to simply send them in blob form.