### PR TITLE
feat(Session): add Session::mock_verify() method

### DIFF
--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -140,6 +140,20 @@ impl Session<Initialized> {
             data: Verified(msr),
         })
     }
+
+    /// Skip verifying the measurement
+    ///
+    /// # Safety
+    ///
+    /// This method must only be used in tests or unattested workflows.
+    pub unsafe fn mock_verify(self, msr: launch::Measurement) -> Result<Session<Verified>> {
+        Ok(Session {
+            policy: self.policy,
+            tek: self.tek,
+            tik: self.tik,
+            data: Verified(msr),
+        })
+    }
 }
 
 impl Session<Measuring> {


### PR DESCRIPTION
*   feat(Session): add Session::mock_verify() method
    
    To skip the `verify` step, because the real digest is unknown,
    CI tests or unattested workflows can use `mock_verify()` to inject a
    "secret", which is not so much a secret anymore.
