### PR TITLE
Replace a matches! macro with a logical equivalent

### DIFF
--- a/src/certs/sev/cert/v1/sig/mod.rs
+++ b/src/certs/sev/cert/v1/sig/mod.rs
@@ -148,17 +148,26 @@ impl TryFrom<&Signature> for Option<crate::certs::Signature> {
 impl Signature {
     #[cfg(feature = "openssl")]
     pub fn is_empty(&self) -> bool {
-        match self.usage {
-            Usage::OCA | Usage::CEK | Usage::PEK | Usage::PDH | Usage::ARK | Usage::ASK => {
-                !matches!(
-                    self.algo,
-                    Algorithm::RSA_SHA256
-                        | Algorithm::RSA_SHA384
-                        | Algorithm::ECDSA_SHA256
-                        | Algorithm::ECDSA_SHA384
-                )
-            }
-            _ => true,
+        let usages = [
+            Usage::OCA,
+            Usage::CEK,
+            Usage::PEK,
+            Usage::PDH,
+            Usage::ARK,
+            Usage::ASK,
+        ];
+
+        let algos = [
+            Algorithm::RSA_SHA256,
+            Algorithm::RSA_SHA384,
+            Algorithm::ECDSA_SHA256,
+            Algorithm::ECDSA_SHA384,
+        ];
+
+        if usages.iter().any(|u| *u == self.usage) && algos.iter().any(|a| *a == self.algo) {
+            false
+        } else {
+            true
         }
     }
 }


### PR DESCRIPTION
The matches! macro was introduced in Rust 1.42, however, as of
this commit, the Rust build toolchain shipped in CentOS is 1.41,
so the sev crate will fail to build from source. While we do not
currently ship the sev crate as an RPM, it is built as part of
sevctl's dependency graph which I'm working on packaging right
now.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
