### PR TITLE
impl From<Indeterminate<Error>> for std::io::Error

### DIFF
--- a/src/util/cached_chain.rs
+++ b/src/util/cached_chain.rs
@@ -55,8 +55,7 @@ pub fn sys() -> Option<PathBuf> {
 pub fn path() -> Vec<PathBuf> {
     vec![env_var(), home(), sys()]
         .into_iter()
-        .filter(|p| p.is_some())
-        .map(|p| p.unwrap())
+        .flatten()
         .collect()
 }
 


### PR DESCRIPTION
Implementing #31 allowing more convenience for callers. If Indeterminate<Error> is a known IoError, the io::Error can simply be returned for context. If not, io::Error::Other is returned.