### PR TITLE
Don't take ownership during verification

### DIFF
--- a/src/certs/ca/chain.rs
+++ b/src/certs/ca/chain.rs
@@ -45,12 +45,12 @@ impl codicon::Encoder<()> for Chain {
 }
 
 #[cfg(feature = "openssl")]
-impl Verifiable for Chain {
-    type Output = Certificate;
+impl<'a> Verifiable for &'a Chain {
+    type Output = &'a Certificate;
 
-    fn verify(self) -> Result<Certificate> {
+    fn verify(self) -> Result<Self::Output> {
         (&self.ark, &self.ark).verify()?;
         (&self.ark, &self.ask).verify()?;
-        Ok(self.ask)
+        Ok(&self.ask)
     }
 }

--- a/src/certs/chain.rs
+++ b/src/certs/chain.rs
@@ -37,12 +37,12 @@ impl codicon::Encoder<()> for Chain {
 }
 
 #[cfg(feature = "openssl")]
-impl Verifiable for Chain {
-    type Output = sev::Certificate;
+impl<'a> Verifiable for &'a Chain {
+    type Output = &'a sev::Certificate;
 
-    fn verify(self) -> Result<sev::Certificate> {
+    fn verify(self) -> Result<Self::Output> {
         let ask = self.ca.verify()?;
-        (&ask, &self.sev.cek).verify()?;
+        (ask, &self.sev.cek).verify()?;
         self.sev.verify()
     }
 }

--- a/src/certs/sev/chain.rs
+++ b/src/certs/sev/chain.rs
@@ -63,14 +63,14 @@ impl codicon::Encoder<()> for Chain {
 }
 
 #[cfg(feature = "openssl")]
-impl Verifiable for Chain {
-    type Output = Certificate;
+impl<'a> Verifiable for &'a Chain {
+    type Output = &'a Certificate;
 
-    fn verify(self) -> Result<Certificate> {
+    fn verify(self) -> Result<Self::Output> {
         (&self.oca, &self.oca).verify()?;
         (&self.oca, &self.pek).verify()?;
         (&self.cek, &self.pek).verify()?;
         (&self.pek, &self.pdh).verify()?;
-        Ok(self.pdh)
+        Ok(&self.pdh)
     }
 }


### PR DESCRIPTION
Otherwise the borrow checker will complain if one tries to
verify a certificate chain before passing it in to a Session<Start>
constructor function.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
