### PR TITLE
Export the type-state types for Launcher

### DIFF
--- a/src/launch/launcher.rs
+++ b/src/launch/launcher.rs
@@ -13,8 +13,13 @@ use std::io::Result;
 use std::mem::MaybeUninit;
 use std::os::unix::io::AsRawFd;
 
+/// Launcher type-state that indicates a brand new launch.
 pub struct New;
+
+/// Launcher type-state that indicates an in-progress launch.
 pub struct Started(Handle);
+
+/// Launcher type-state that indicates the availability of a measurement.
 pub struct Measured(Handle, Measurement);
 
 /// Facilitates the correct execution of the SEV launch process.

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -10,7 +10,7 @@ mod launcher;
 #[cfg(target_os = "linux")]
 mod linux;
 
-pub use launcher::Launcher;
+pub use launcher::{Launcher, Measured, New, Started};
 
 use super::*;
 use bitflags::bitflags;


### PR DESCRIPTION
If they're not exported, then callers can't stash intermediate launcher
states into a struct.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
