### PR TITLE
Appease our ever-vigilant and meticulous overlord, Clippy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.42.0
+          - 1.51.0
         profile:
           - name: debug
           - name: release

--- a/src/certs/ca/cert/v1.rs
+++ b/src/certs/ca/cert/v1.rs
@@ -24,11 +24,11 @@ enum Size {
 }
 
 #[cfg(feature = "openssl")]
-impl Into<hash::MessageDigest> for Size {
-    fn into(self) -> hash::MessageDigest {
-        match self {
-            Self::Small => hash::MessageDigest::sha256(),
-            Self::Large => hash::MessageDigest::sha384(),
+impl From<Size> for hash::MessageDigest {
+    fn from(size: Size) -> Self {
+        match size {
+            Size::Small => hash::MessageDigest::sha256(),
+            Size::Large => hash::MessageDigest::sha384(),
         }
     }
 }

--- a/src/certs/crypto.rs
+++ b/src/certs/crypto.rs
@@ -59,11 +59,10 @@ impl<U: Copy + Into<Usage>> std::fmt::Display for PublicKey<U> {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         use std::fmt::Error;
 
-        let sig = match self.usage.into() {
-            Usage::CEK | Usage::OCA | Usage::PEK => true,
-            Usage::ARK | Usage::ASK => true,
-            _ => false,
-        };
+        let sig = matches!(
+            self.usage.into(),
+            Usage::CEK | Usage::OCA | Usage::PEK | Usage::ARK | Usage::ASK
+        );
 
         match (sig, self.key.id()) {
             (true, pkey::Id::RSA) => write!(

--- a/src/certs/sev/cert/mod.rs
+++ b/src/certs/sev/cert/mod.rs
@@ -173,7 +173,9 @@ impl TryFrom<&Certificate> for PublicKey<Usage> {
 
     fn try_from(value: &Certificate) -> Result<Self> {
         match value.version() {
-            1 => PublicKey::try_from(unsafe { &value.v1.body.data.key }),
+            1 => PublicKey::try_from(unsafe {
+                &std::ptr::addr_of!(value.v1.body.data.key).read_unaligned()
+            }),
             _ => Err(ErrorKind::InvalidInput.into()),
         }
     }

--- a/src/certs/sev/cert/mod.rs
+++ b/src/certs/sev/cert/mod.rs
@@ -190,7 +190,7 @@ impl Verifiable for (&Certificate, &Certificate) {
 
         let sigs: [Option<Signature>; 2] = self.1.try_into()?;
         for sig in sigs.iter().flatten() {
-            if key.verify(self.1, &sig).is_ok() {
+            if key.verify(self.1, sig).is_ok() {
                 return Ok(());
             }
         }
@@ -208,7 +208,7 @@ impl Verifiable for (&ca::Certificate, &Certificate) {
 
         let sigs: [Option<Signature>; 2] = self.1.try_into()?;
         for sig in sigs.iter().flatten() {
-            if key.verify(self.1, &sig).is_ok() {
+            if key.verify(self.1, sig).is_ok() {
                 return Ok(());
             }
         }

--- a/src/certs/sev/cert/mod.rs
+++ b/src/certs/sev/cert/mod.rs
@@ -189,11 +189,9 @@ impl Verifiable for (&Certificate, &Certificate) {
         let key = PublicKey::try_from(self.0)?;
 
         let sigs: [Option<Signature>; 2] = self.1.try_into()?;
-        for sig in sigs.iter() {
-            if let Some(sig) = sig {
-                if key.verify(self.1, &sig).is_ok() {
-                    return Ok(());
-                }
+        for sig in sigs.iter().flatten() {
+            if key.verify(self.1, &sig).is_ok() {
+                return Ok(());
             }
         }
 
@@ -209,11 +207,9 @@ impl Verifiable for (&ca::Certificate, &Certificate) {
         let key: PublicKey<ca::Usage> = self.0.try_into()?;
 
         let sigs: [Option<Signature>; 2] = self.1.try_into()?;
-        for sig in sigs.iter() {
-            if let Some(sig) = sig {
-                if key.verify(self.1, &sig).is_ok() {
-                    return Ok(());
-                }
+        for sig in sigs.iter().flatten() {
+            if key.verify(self.1, &sig).is_ok() {
+                return Ok(());
             }
         }
 

--- a/src/certs/sev/cert/v1/body/key/ecc/mod.rs
+++ b/src/certs/sev/cert/v1/body/key/ecc/mod.rs
@@ -70,8 +70,8 @@ impl TryFrom<&ec::EcKey<pkey::Private>> for PubKey {
             .affine_coordinates_gfp(g, &mut x, &mut y, &mut c)?;
         Ok(Self {
             g: group::Group::try_from(g)?,
-            x: x.into_le(),
-            y: y.into_le(),
+            x: x.as_le_bytes(),
+            y: y.as_le_bytes(),
         })
     }
 }

--- a/src/certs/sev/cert/v1/body/key/rsa.rs
+++ b/src/certs/sev/cert/v1/body/key/rsa.rs
@@ -71,8 +71,8 @@ impl TryFrom<&PubKey> for pkey::PKey<pkey::Public> {
 impl PubKey {
     pub fn generate(bits: u32) -> Result<(Self, rsa::Rsa<pkey::Private>)> {
         let prv = rsa::Rsa::generate(bits)?;
-        let n = prv.n().into_le();
-        let e = prv.e().into_le();
+        let n = prv.n().as_le_bytes();
+        let e = prv.e().as_le_bytes();
         Ok((
             Self {
                 modulus_size: bits.to_le(),

--- a/src/certs/sev/cert/v1/sig/ecdsa.rs
+++ b/src/certs/sev/cert/v1/sig/ecdsa.rs
@@ -42,8 +42,8 @@ impl From<ecdsa::EcdsaSig> for Signature {
     #[inline]
     fn from(value: ecdsa::EcdsaSig) -> Self {
         Signature {
-            r: value.r().into_le(),
-            s: value.s().into_le(),
+            r: value.r().as_le_bytes(),
+            s: value.s().as_le_bytes(),
         }
     }
 }

--- a/src/certs/sev/cert/v1/sig/rsa.rs
+++ b/src/certs/sev/cert/v1/sig/rsa.rs
@@ -30,7 +30,7 @@ impl Default for Signature {
 impl From<bn::BigNum> for Signature {
     #[inline]
     fn from(value: bn::BigNum) -> Self {
-        Signature(value.into_le())
+        Signature(value.as_le_bytes())
     }
 }
 

--- a/src/certs/sev/cert/v1/sig/rsa.rs
+++ b/src/certs/sev/cert/v1/sig/rsa.rs
@@ -50,7 +50,7 @@ impl TryFrom<&Signature> for bn::BigNum {
 
     #[inline]
     fn try_from(value: &Signature) -> Result<Self> {
-        Ok(bn::BigNum::from_le(&value.0)?)
+        bn::BigNum::from_le(&value.0)
     }
 }
 

--- a/src/certs/util.rs
+++ b/src/certs/util.rs
@@ -6,8 +6,8 @@ pub trait FromLe: Sized {
     fn from_le(value: &[u8]) -> Result<Self>;
 }
 
-pub trait IntoLe<T> {
-    fn into_le(&self) -> T;
+pub trait AsLeBytes<T> {
+    fn as_le_bytes(&self) -> T;
 }
 
 impl FromLe for openssl::bn::BigNum {
@@ -19,8 +19,8 @@ impl FromLe for openssl::bn::BigNum {
     }
 }
 
-impl IntoLe<[u8; 72]> for openssl::bn::BigNumRef {
-    fn into_le(&self) -> [u8; 72] {
+impl AsLeBytes<[u8; 72]> for openssl::bn::BigNumRef {
+    fn as_le_bytes(&self) -> [u8; 72] {
         let mut buf = [0u8; 72];
 
         for (i, b) in self.to_vec().iter().rev().cloned().enumerate() {
@@ -31,8 +31,8 @@ impl IntoLe<[u8; 72]> for openssl::bn::BigNumRef {
     }
 }
 
-impl IntoLe<[u8; 512]> for openssl::bn::BigNumRef {
-    fn into_le(&self) -> [u8; 512] {
+impl AsLeBytes<[u8; 512]> for openssl::bn::BigNumRef {
+    fn as_le_bytes(&self) -> [u8; 512] {
         let mut buf = [0u8; 512];
 
         for (i, b) in self.to_vec().iter().rev().cloned().enumerate() {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -202,7 +202,7 @@ impl Session<Verified> {
         sig.sign(&mut mac)?;
 
         Ok(launch::Secret {
-            header: launch::Header { flags, mac, iv },
+            header: launch::Header { flags, iv, mac },
             ciphertext,
         })
     }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -87,7 +87,7 @@ impl Session<Initialized> {
         let pdh = chain.verify()?;
         let (crt, prv) = sev::Certificate::generate(sev::Usage::PDH)?;
 
-        let z = key::Key::new(prv.derive(&pdh)?);
+        let z = key::Key::new(prv.derive(pdh)?);
         let mut nonce = [0u8; 16];
         let mut iv = [0u8; 16];
         rand::rand_bytes(&mut nonce)?;
@@ -126,7 +126,7 @@ impl Session<Initialized> {
         sig.update(&[0x04u8])?;
         sig.update(&[build.version.major, build.version.minor, build.build])?;
         sig.update(&self.policy.bytes())?;
-        sig.update(&digest)?;
+        sig.update(digest)?;
         sig.update(&msr.mnonce)?;
 
         if sig.sign_to_vec()? != msr.measure {


### PR DESCRIPTION
Alright, that was a lot of elbow grease. Frankly, I found clippy's error about `IntoLe` to be a little bit too opinionated, but changed it anyway. I'm guessing that patch might be the most controversial, since I did not rename the `FromLe` trait, as I found that naming scheme conflicted with integer's `from_le_bytes` etc. I'm open to suggestions.

edit: the 1.42.0 checks will never check in with us, since they have been replaced with the new minimum compiler.