### PR TITLE
Remove just-in-time certificate signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,4 @@ dirs = "3.0"
 kvm-bindings = "0.4"
 kvm-ioctls = "0.9"
 mmarinus = "0.2"
-reqwest =  { version = "0.10", features = ["blocking"] }
 serial_test = "0.5"


### PR DESCRIPTION
Obsoletes #50 

The only situation in which this is useful is if the certificate chain
doesn't exist in the first place. This doesn't buy us anything if the
certificate chain exists but is invalid (i.e., it was exported and then
someone ran a platform reset).

Before, running the test suite would build 150 crates. Now, it builds
61.

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>
