### PR TITLE
Re-shape PlatformStatus into sev_user_data_status

### DIFF
--- a/src/firmware/linux/mod.rs
+++ b/src/firmware/linux/mod.rs
@@ -34,7 +34,6 @@ impl Firmware {
     pub fn platform_status(&mut self) -> Result<Status, Indeterminate<Error>> {
         let mut info: PlatformStatus = Default::default();
         PLATFORM_STATUS.ioctl(&mut self.0, &mut Command::from_mut(&mut info))?;
-        let config = info.config;
 
         Ok(Status {
             build: Build {
@@ -42,10 +41,10 @@ impl Firmware {
                     major: info.version.major,
                     minor: info.version.minor,
                 },
-                build: config.build() as _,
+                build: info.build,
             },
             guests: info.guest_count,
-            flags: Flags::from_bits_truncate(info.flags.bits().into()),
+            flags: info.flags,
             state: match info.state {
                 0 => State::Uninitialized,
                 1 => State::Initialized,

--- a/src/firmware/mod.rs
+++ b/src/firmware/mod.rs
@@ -10,10 +10,10 @@ use super::*;
 use std::fmt::Debug;
 use std::{error, io};
 
-use bitflags::bitflags;
-
 #[cfg(target_os = "linux")]
 pub use linux::Firmware;
+
+pub use types::PlatformStatusFlags;
 
 /// There are a number of error conditions that can occur between this
 /// layer all the way down to the SEV platform. Most of these cases have
@@ -240,18 +240,6 @@ pub enum State {
     Working,
 }
 
-bitflags! {
-    /// Describes the platform state.
-    #[derive(Default)]
-    pub struct Flags: u32 {
-        /// If set, this platform is owned. Otherwise, it is self-owned.
-        const OWNED           = 1 << 0;
-
-        /// If set, encrypted state functionality is present.
-        const ENCRYPTED_STATE = 1 << 8;
-    }
-}
-
 /// Information regarding the SEV platform's current status.
 #[derive(Clone, Debug, PartialEq)]
 pub struct Status {
@@ -265,7 +253,7 @@ pub struct Status {
     ///
     /// These could describe whether encrypted state functionality
     /// is enabled, or whether the platform is self-owned.
-    pub flags: Flags,
+    pub flags: PlatformStatusFlags,
 
     /// The number of valid guests supervised by this platform.
     pub guests: u32,

--- a/src/firmware/types.rs
+++ b/src/firmware/types.rs
@@ -14,26 +14,13 @@ pub struct PlatformReset;
 bitflags::bitflags! {
     /// The platform's status flags.
     #[derive(Default)]
-    pub struct PlatformStatusFlags: u8 {
-    /// If set, the platform is externally owned.
-    /// Else, it is self-owned (default state).
-        const OWNER = 1;
+    pub struct PlatformStatusFlags: u32 {
+        /// If set, this platform is owned. Otherwise, it is self-owned.
+        const OWNED           = 1 << 0;
+
+        /// If set, encrypted state functionality is present.
+        const ENCRYPTED_STATE = 1 << 8;
     }
-}
-
-bitfield::bitfield! {
-    /// Contains information that describes how the
-    /// platform is currently configured.
-    #[derive(Clone, Copy, Default, PartialEq, Eq)]
-    pub struct PlatformStatusConfig(u32);
-    impl Debug;
-
-    /// If set, SEV-ES is initialized for the platform.
-    pub encrypted_state, _: 0, 0;
-    reserved, _: 23, 1;
-
-    /// The firmware build ID for this API version.
-    pub build, _: 31, 24;
 }
 
 /// Query SEV platform status.
@@ -56,8 +43,8 @@ pub struct PlatformStatus {
     /// state.
     pub flags: PlatformStatusFlags,
 
-    /// Contains configuration information about the platform.
-    pub config: PlatformStatusConfig,
+    /// The firmware build ID for this API version.
+    pub build: u8,
 
     /// The number of valid guests maintained by the SEV firmware.
     pub guest_count: u32,


### PR DESCRIPTION
This struct must take the form of the sev_user_data_status struct that the
AMD SEV kernel module exports. Right now, it resembles the command buffer
that the kernel is meant to send to the firmware; which is wrong because
the struct exported by the kernel and the command buffer that the firmware
expects are different. This results in data loss (most recently observed in
losing information in the flags variable).

For example, when running `sevctl show flags` on Rome (without this patch):

[connorkuehl@rome sevctl]$ cargo run -- show flags
   Compiling sevctl v0.1.0 (/home/connorkuehl/git/sevctl)
    Finished dev [unoptimized + debuginfo] target(s) in 2.16s
     Running `target/debug/sevctl show flags`
owned

^^^
Note that the "es" flag we expect to see is missing.

With this patch:

[connorkuehl@rome sevctl]$ cargo run -- show flags
   Compiling sev v0.1.0 (/home/connorkuehl/git/sev)
   Compiling sevctl v0.1.0 (/home/connorkuehl/git/sevctl)
    Finished dev [unoptimized + debuginfo] target(s) in 3.27s
     Running `target/debug/sevctl show flags`
owned
es

Signed-off-by: Connor Kuehl <ckuehl@redhat.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
