### PR TITLE
fix: update to sev-snp-part2-v5

### DIFF
--- a/src/firmware/linux/ioctl.rs
+++ b/src/firmware/linux/ioctl.rs
@@ -23,7 +23,7 @@ impl_const_id! {
     PekCertImport<'_> = 6,
     GetId<'_> = 8, /* GET_ID2 is 8, the deprecated GET_ID ioctl is 7 */
 
-    SnpPlatformStatus = 256,
+    SnpPlatformStatus = 9,
 }
 
 const SEV: Group = Group::new(b'S');

--- a/src/kvm/types.rs
+++ b/src/kvm/types.rs
@@ -142,6 +142,8 @@ pub struct SnpLaunchStart<'a> {
     /// The format is hypervisor defined.
     gosvw: [u8; 16],
 
+    pad: [u8; 6],
+
     _phantom: PhantomData<&'a [u8]>,
 }
 
@@ -159,6 +161,7 @@ impl<'a> SnpLaunchStart<'a> {
             ma_en: start.ma_en as _,
             imi_en: start.imi_en as _,
             gosvw: start.gosvw,
+            pad: [0u8; 6],
             _phantom: PhantomData,
         }
     }
@@ -167,6 +170,9 @@ impl<'a> SnpLaunchStart<'a> {
 /// Insert pages into the guest physical address space.
 #[repr(C)]
 pub struct SnpLaunchUpdate<'a> {
+    /// guest start frame number.
+    start_gfn: u64,
+
     /// Userspace address of the page needed to be encrypted.
     uaddr: u64,
 
@@ -196,6 +202,7 @@ pub struct SnpLaunchUpdate<'a> {
 impl<'a, 'b> SnpLaunchUpdate<'a> {
     pub fn new(update: &'a SnpUpdate) -> Self {
         Self {
+            start_gfn: update.start_gfn,
             uaddr: update.uaddr.as_ptr() as _,
             len: update.uaddr.len() as _,
             imi_page: if update.imi_page { 1 } else { 0 },
@@ -229,6 +236,8 @@ pub struct SnpLaunchFinish<'a> {
     /// Opaque host-supplied data to describe the guest. The firmware does not interpret this value.
     host_data: [u8; KVM_SEV_SNP_FINISH_DATA_SIZE],
 
+    pad: [u8; 6],
+
     _phantom: PhantomData<&'a [u8]>,
 }
 
@@ -252,6 +261,7 @@ impl<'a> SnpLaunchFinish<'a> {
             id_block_en: if finish.id_block_en { 1 } else { 0 },
             auth_key_en: if finish.auth_key_en { 1 } else { 0 },
             host_data: finish.host_data,
+            pad: [0u8; 6],
             _phantom: PhantomData,
         }
     }

--- a/src/launch/linux/ioctl.rs
+++ b/src/launch/linux/ioctl.rs
@@ -20,10 +20,10 @@ impl_const_id! {
     LaunchMeasure<'_> = 6,
     LaunchFinish = 7,
 
-    SnpInit = 256,
-    SnpLaunchStart<'_> = 257,
-    SnpLaunchUpdate<'_> = 258,
-    SnpLaunchFinish<'_> = 259,
+    SnpInit = 22,
+    SnpLaunchStart<'_> = 23,
+    SnpLaunchUpdate<'_> = 24,
+    SnpLaunchFinish<'_> = 25,
 }
 
 const KVM: Group = Group::new(0xAE);

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -289,6 +289,9 @@ impl<'a> SnpStart<'a> {
 /// Encapsulates the various data needed to begin the update process.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct SnpUpdate<'a> {
+    /// guest start frame number.
+    pub start_gfn: u64,
+
     /// The userspace of address of the encrypted region.
     pub uaddr: &'a [u8],
 
@@ -311,12 +314,14 @@ pub struct SnpUpdate<'a> {
 impl<'a> SnpUpdate<'a> {
     /// Encapsulate all data needed for the SNP_LAUNCH_UPDATE ioctl.
     pub fn new(
+        start_gfn: u64,
         uaddr: &'a [u8],
         imi_page: bool,
         page_type: SnpPageType,
         perms: (VmplPerms, VmplPerms, VmplPerms),
     ) -> Self {
         Self {
+            start_gfn,
             uaddr,
             imi_page,
             page_type,

--- a/tests/snp_launch.rs
+++ b/tests/snp_launch.rs
@@ -161,6 +161,7 @@ fn snp() {
     let dp = VmplPerms::empty();
 
     let update = SnpUpdate::new(
+        mem_region.guest_phys_addr >> 12,
         address_space.as_ref(),
         false,
         SnpPageType::Normal,


### PR DESCRIPTION
correct structures and ioctl numbers according to
https://github.com/AMDESE/linux branch sev-snp-part2-v5

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
