### PR TITLE
Usability patches

### DIFF
--- a/src/launch/linux/mod.rs
+++ b/src/launch/linux/mod.rs
@@ -1,3 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! Operations for launching on Linux
+
 pub mod ioctl;

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -7,7 +7,7 @@
 //! for navigating the AMD SEV launch process for a virtual machine.
 
 #[cfg(target_os = "linux")]
-mod linux;
+pub mod linux;
 
 pub mod sev;
 pub mod snp;

--- a/src/launch/sev.rs
+++ b/src/launch/sev.rs
@@ -77,7 +77,7 @@ impl<'a, U: AsRawFd, V: AsRawFd> Launcher<'a, Started, U, V> {
         let launch_update_data = LaunchUpdateData::new(data);
         let mut cmd = Command::from(self.sev, &launch_update_data);
 
-        ENC_REG_REGION.ioctl(self.vm_fd, &KvmEncRegion::new(data))?;
+        KvmEncRegion::new(data).register(self.vm_fd)?;
 
         LAUNCH_UPDATE_DATA
             .ioctl(self.vm_fd, &mut cmd)

--- a/src/launch/snp.rs
+++ b/src/launch/snp.rs
@@ -87,7 +87,7 @@ impl<'a, U: AsRawFd, V: AsRawFd> Launcher<'a, Started, U, V> {
         let launch_update_data = SnpLaunchUpdate::new(&update);
         let mut cmd = Command::from(self.sev, &launch_update_data);
 
-        ENC_REG_REGION.ioctl(self.vm_fd, &KvmEncRegion::new(update.uaddr))?;
+        KvmEncRegion::new(update.uaddr).register(self.vm_fd)?;
 
         SNP_LAUNCH_UPDATE
             .ioctl(self.vm_fd, &mut cmd)

--- a/src/util/impl_const_id.rs
+++ b/src/util/impl_const_id.rs
@@ -6,12 +6,15 @@
 #[macro_export]
 macro_rules! impl_const_id {
     (
+        $(#[$outer:meta])*
         $visibility:vis $trait:ident => $id_ty:ty;
         $(
             $iocty:ty = $val:expr
         ),* $(,)*
     ) => {
+        $(#[$outer])*
         $visibility trait $trait {
+            $(#[$outer])*
             const ID: $id_ty;
         }
 

--- a/tests/snp_launch.rs
+++ b/tests/snp_launch.rs
@@ -102,7 +102,7 @@ fn snp() {
     }
 
     let kvm_fd = Kvm::new().unwrap();
-    let mut vm_fd = kvm_fd.create_vm().unwrap();
+    let vm_fd = kvm_fd.create_vm().unwrap();
     vm_fd.create_irq_chip().unwrap();
 
     let mut address_space = Map::map(CODE_SIZE)
@@ -144,8 +144,8 @@ fn snp() {
         vm_fd.set_user_memory_region(mem_region).unwrap();
     }
 
-    let mut sev = Firmware::open().unwrap();
-    let launcher = Launcher::new(&mut vm_fd, &mut sev).unwrap();
+    let sev = Firmware::open().unwrap();
+    let launcher = Launcher::new(vm_fd, sev).unwrap();
 
     let start = SnpStart {
         policy: SnpPolicy {
@@ -175,7 +175,7 @@ fn snp() {
     let mut vcpu_fd = launcher.as_mut().create_vcpu(0).unwrap();
     set_cpu(&kvm_fd, &mut vcpu_fd);
 
-    launcher.finish(finish).unwrap();
+    let (_vm_fd, _sev) = launcher.finish(finish).unwrap();
 
     let ret = vcpu_fd.run();
 


### PR DESCRIPTION
* fix: make `sev::launch::linux::ioctl` public 

    We want `ENC_REG_REGION`.

*  fix: take ownership of the AsRawFd in the SNPLauncher
    
    This makes storing of an intermediate
    `Launcher<Started, VmFd, Firmware>` much easier without the lifetimes
    involved and we don't have to cope with storing the AsRawFd objects
    somewhere else with an even longer lifetime.
