### PR TITLE
Avoid exporting `kvm` module outside crate boundary

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 
 pub mod certs;
 pub mod firmware;
-pub mod kvm;
+pub(crate) mod kvm;
 pub mod launch;
 #[cfg(feature = "openssl")]
 pub mod session;


### PR DESCRIPTION
Refs #76 (I suppose that one matches the scope the best?)

KVM module does not provide any functionality exported outside of this crate, hence avoid making it public outside crate boundary.
Before:
![2021-10-07-10:10:58-screenshot](https://user-images.githubusercontent.com/12877905/136345561-61a0403f-0ae8-43d5-a0b7-fa9404bff5db.png)

![2021-10-07-10:08:21-screenshot](https://user-images.githubusercontent.com/12877905/136345357-885ebf86-2aa1-4e46-98f6-5ba1b65ab8af.png)

After:
![2021-10-07-10:10:35-screenshot](https://user-images.githubusercontent.com/12877905/136345482-d4a174f7-2f5a-48a6-ba4c-e5e9ad229095.png)
