### PR TITLE
Ensure URLs in documentation are clickable

### DIFF
--- a/src/certs/builtin/milan/mod.rs
+++ b/src/certs/builtin/milan/mod.rs
@@ -2,7 +2,7 @@
 
 //! AMD's Milan certificates.
 //!
-//! Certificate provenance: https://developer.amd.com/wp-content/resources/ask_ark_milan.cert
+//! Certificate provenance: <https://developer.amd.com/wp-content/resources/ask_ark_milan.cert>
 //!
 //! For convenience, the certificate chain has been split into individual
 //! certificates and are embedded here as byte slices.

--- a/src/certs/builtin/naples/mod.rs
+++ b/src/certs/builtin/naples/mod.rs
@@ -2,7 +2,7 @@
 
 //! AMD's Naples certificates.
 //!
-//! Certificate provenance: https://developer.amd.com/wp-content/resources/ask_ark_naples.cert
+//! Certificate provenance: <https://developer.amd.com/wp-content/resources/ask_ark_naples.cert>
 //!
 //! For convenience, the certificate chain has been split into individual
 //! certificates and are embedded here as byte slices.

--- a/src/certs/builtin/rome/mod.rs
+++ b/src/certs/builtin/rome/mod.rs
@@ -2,7 +2,7 @@
 
 //! AMD's Rome certificates.
 //!
-//! Certificate provenance: https://developer.amd.com/wp-content/resources/ask_ark_rome.cert
+//! Certificate provenance: <https://developer.amd.com/wp-content/resources/ask_ark_rome.cert>
 //!
 //! For convenience, the certificate chain has been split into individual
 //! certificates and are embedded here as byte slices.


### PR DESCRIPTION
Again, _I guess_ refs #76 

Before:
![2021-10-07-10:24:01-screenshot](https://user-images.githubusercontent.com/12877905/136347692-dbacb951-68ae-4976-b513-47cf0761934b.png)

After:
![2021-10-07-10:24:20-screenshot](https://user-images.githubusercontent.com/12877905/136347711-3978521e-e145-439b-bad7-c4bf0cedff59.png)

(ditto for the other 2 modules)