### PR TITLE
Hide `launch::linux::ioctl` across crate boundary

### DIFF
--- a/src/launch/linux/ioctl.rs
+++ b/src/launch/linux/ioctl.rs
@@ -71,10 +71,6 @@ pub const LAUNCH_FINISH: Ioctl<WriteRead, &Command<sev::LaunchFinish>> = unsafe 
 pub const ENC_REG_REGION: Ioctl<Write, &KvmEncRegion> =
     unsafe { KVM.read::<KvmEncRegion>(0xBB).lie() };
 
-/// Corresponds to the `KVM_MEMORY_ENCRYPT_UNREG_REGION` ioctl
-pub const ENC_UNREG_REGION: Ioctl<Write, &KvmEncRegion> =
-    unsafe { KVM.read::<KvmEncRegion>(0xBC).lie() };
-
 /// Initialize the SEV-SNP platform in KVM.
 pub const SNP_INIT: Ioctl<WriteRead, &Command<snp::Init>> = unsafe { ENC_OP.lie() };
 

--- a/src/launch/linux/mod.rs
+++ b/src/launch/linux/mod.rs
@@ -2,6 +2,6 @@
 
 //! Operations and types for launching on Linux
 
-pub mod ioctl;
+pub(crate) mod ioctl;
 pub(crate) mod sev;
 pub(crate) mod snp;

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -7,7 +7,7 @@
 //! for navigating the AMD SEV launch process for a virtual machine.
 
 #[cfg(target_os = "linux")]
-pub mod linux;
+mod linux;
 
 pub mod sev;
 pub mod snp;


### PR DESCRIPTION
Closes #77 
- hide `launch::linux` module
- now that `launch::linux::ioctl` module is public within the crate only, remove unregister ioctl, since it is not used within the crate (for now).

https://github.com/enarx/sev/issues/77#issuecomment-934197652 will be provided by https://github.com/rust-vmm/kvm-ioctls/pull/178 once merged