### PR TITLE
fix: correct the SnpPlatformStatus struct

### DIFF
--- a/src/firmware/linux/mod.rs
+++ b/src/firmware/linux/mod.rs
@@ -133,12 +133,15 @@ impl Firmware {
             },
             guests: info.guest_count,
             tcb_version: info.tcb_version,
+            is_rmp_init: info.is_rmp_init == 1,
+            mask_chip_id: info.mask_chip_id == 1,
             state: match info.state {
                 0 => State::Uninitialized,
                 1 => State::Initialized,
                 // SNP platforms cannot be in the 'Working' State.
                 _ => return Err(Indeterminate::Unknown),
             },
+            reported_tcb_version: info.reported_tcb_version,
         })
     }
 }

--- a/src/firmware/linux/mod.rs
+++ b/src/firmware/linux/mod.rs
@@ -132,7 +132,10 @@ impl Firmware {
                 build: info.build_id,
             },
             guests: info.guest_count,
-            tcb_version: info.tcb_version,
+            tcb: SnpTcbStatus {
+                platform_version: info.platform_tcb_version,
+                reported_version: info.reported_tcb_version,
+            },
             is_rmp_init: info.is_rmp_init == 1,
             mask_chip_id: info.mask_chip_id == 1,
             state: match info.state {
@@ -141,7 +144,6 @@ impl Firmware {
                 // SNP platforms cannot be in the 'Working' State.
                 _ => return Err(Indeterminate::Unknown),
             },
-            reported_tcb_version: info.reported_tcb_version,
         })
     }
 }

--- a/src/firmware/mod.rs
+++ b/src/firmware/mod.rs
@@ -15,7 +15,7 @@ use std::{error, io};
 #[cfg(target_os = "linux")]
 pub use linux::Firmware;
 
-pub use types::PlatformStatusFlags;
+pub use types::{PlatformStatusFlags, TcbVersion};
 
 /// There are a number of error conditions that can occur between this
 /// layer all the way down to the SEV platform. Most of these cases have
@@ -304,6 +304,16 @@ impl std::fmt::Display for Identifier {
     }
 }
 
+/// Information regarding the SEV-SNP platform's TCB version.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SnpTcbStatus {
+    /// Installed TCB version.
+    pub platform_version: TcbVersion,
+
+    /// Reported TCB version.
+    pub reported_version: TcbVersion,
+}
+
 /// Information regarding the SEV-SNP platform's current status.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SnpStatus {
@@ -322,9 +332,6 @@ pub struct SnpStatus {
     /// The number of valid guests supervised by this platform.
     pub guests: u32,
 
-    /// The installed TCB version.
-    pub tcb_version: u64,
-
-    /// reported TCB version
-    pub reported_tcb_version: u64,
+    /// TCB status.
+    pub tcb: SnpTcbStatus,
 }

--- a/src/firmware/mod.rs
+++ b/src/firmware/mod.rs
@@ -313,9 +313,18 @@ pub struct SnpStatus {
     /// The platform's current state.
     pub state: State,
 
+    /// IsRmpInitiailzied
+    pub is_rmp_init: bool,
+
+    /// MaskChipId
+    pub mask_chip_id: bool,
+
     /// The number of valid guests supervised by this platform.
     pub guests: u32,
 
     /// The installed TCB version.
     pub tcb_version: u64,
+
+    /// reported TCB version
+    pub reported_tcb_version: u64,
 }

--- a/src/firmware/types.rs
+++ b/src/firmware/types.rs
@@ -152,6 +152,26 @@ impl<'a> GetId<'a> {
     }
 }
 
+/// TcbVersion represents the version of the firmware.
+///
+/// (Chapter 2.2; Table 3)
+#[derive(Clone, Debug, Default, PartialEq)]
+#[repr(C)]
+pub struct TcbVersion {
+    /// Current bootloader version.
+    /// SVN of PSP bootloader.
+    pub bootloader: u8,
+    /// Current PSP OS version.
+    /// SVN of PSP operating system.
+    pub tee: u8,
+    _reserved: [u8; 4],
+    /// Version of the SNP firmware.
+    /// Security Version Number (SVN) of SNP firmware.
+    pub snp: u8,
+    /// Lowest current patch level of all the cores.
+    pub microcode: u8,
+}
+
 /// Query the SEV-SNP platform status.
 ///
 /// (Chapter 8.3; Table 38)
@@ -176,9 +196,9 @@ pub struct SnpPlatformStatus {
     /// The number of valid guests maintained by the SEV-SNP firmware.
     pub guest_count: u32,
 
-    /// The installed TCB version.
-    pub tcb_version: u64,
+    /// Installed TCB version.
+    pub platform_tcb_version: TcbVersion,
 
-    /// reported TCB version
-    pub reported_tcb_version: u64,
+    /// Reported TCB version.
+    pub reported_tcb_version: TcbVersion,
 }

--- a/src/firmware/types.rs
+++ b/src/firmware/types.rs
@@ -156,7 +156,7 @@ impl<'a> GetId<'a> {
 ///
 /// (Chapter 8.3; Table 38)
 #[derive(Default)]
-#[repr(C, packed)]
+#[repr(C)]
 pub struct SnpPlatformStatus {
     /// The firmware API version (major.minor)
     pub version: Version,
@@ -164,12 +164,21 @@ pub struct SnpPlatformStatus {
     /// The platform state.
     pub state: u8,
 
+    /// IsRmpInitiailzied
+    pub is_rmp_init: u8,
+
     /// The platform build ID.
     pub build_id: u32,
+
+    /// MaskChipId
+    pub mask_chip_id: u32,
 
     /// The number of valid guests maintained by the SEV-SNP firmware.
     pub guest_count: u32,
 
     /// The installed TCB version.
     pub tcb_version: u64,
+
+    /// reported TCB version
+    pub reported_tcb_version: u64,
 }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -127,19 +127,19 @@ fn snp_platform_status() {
     let status = fw.snp_platform_status().unwrap();
 
     println!(
-        "Platform status ioctl results:\n
-              version (major, minor): {}.{}\n
-              build id: {}\n
-              guests: {}\n
-              platform tcb microcode version: {}\n
-              platform tcb snp version: {}\n
-              platform tcb tee version: {}\n
-              platform tcb bootloader version: {}\n
-              reported tcb microcode version: {}\n
-              reported tcb snp version: {}\n
-              reported tcb tee version: {}\n
-              reported tcb bootloader version: {}\n
-              state: {}\n",
+        "Platform status ioctl results:
+              version (major, minor): {}.{}
+              build id: {}
+              guests: {}
+              platform tcb microcode version: {}
+              platform tcb snp version: {}
+              platform tcb tee version: {}
+              platform tcb bootloader version: {}
+              reported tcb microcode version: {}
+              reported tcb snp version: {}
+              reported tcb tee version: {}
+              reported tcb bootloader version: {}
+              state: {}",
         status.build.version.major,
         status.build.version.minor,
         status.build.build,

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -131,13 +131,27 @@ fn snp_platform_status() {
               version (major, minor): {}.{}\n
               build id: {}\n
               guests: {}\n
-              tcb version: {}\n
+              platform tcb microcode version: {}\n
+              platform tcb snp version: {}\n
+              platform tcb tee version: {}\n
+              platform tcb bootloader version: {}\n
+              reported tcb microcode version: {}\n
+              reported tcb snp version: {}\n
+              reported tcb tee version: {}\n
+              reported tcb bootloader version: {}\n
               state: {}\n",
         status.build.version.major,
         status.build.version.minor,
         status.build.build,
         status.guests,
-        status.tcb_version,
+        status.tcb.platform_version.microcode,
+        status.tcb.platform_version.snp,
+        status.tcb.platform_version.tee,
+        status.tcb.platform_version.bootloader,
+        status.tcb.reported_version.microcode,
+        status.tcb.reported_version.snp,
+        status.tcb.reported_version.tee,
+        status.tcb.reported_version.bootloader,
         status.state
     );
 }


### PR DESCRIPTION
This adds the missing fields!

Signed-off-by: Harald Hoyer <harald@profian.com>

<!--
Thanks for opening a pull request and helping improve Enarx.

Please remember to:
- mention any issue(s) that this PR closes using a closing keyword as well as the issue number, such as "Closes #XYZ" or "Resolves enarx/repo-name#XYZ", cf.
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as Enarx uses the [DCO](https://github.com/enarx/enarx/wiki/How-to-contribute-code#developer-certificate-of-origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits
- lastly, ensure there are no merge commits!
Thank you :)
-->
