### PR TITLE
move `kvm` module into `launch::linux`

### DIFF
--- a/src/kvm/mod.rs
+++ b/src/kvm/mod.rs
@@ -1,5 +1,0 @@
-// SPDX-License-Identifier: Apache-2.0
-
-//! Types for interacting with the KVM-SEV guest management API.
-
-pub(crate) mod types;

--- a/src/launch/linux/ioctl.rs
+++ b/src/launch/linux/ioctl.rs
@@ -5,7 +5,7 @@
 
 use crate::firmware::{Error, Indeterminate};
 use crate::impl_const_id;
-use crate::kvm::types::*;
+use crate::launch::linux::kvm::*;
 use iocuddle::*;
 
 use std::marker::PhantomData;

--- a/src/launch/linux/kvm.rs
+++ b/src/launch/linux/kvm.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
+//! Types for interacting with the KVM-SEV guest management API.
+
 use crate::certs::sev;
 use crate::launch::*;
 use crate::launch::{Header, Measurement, Policy, Session};

--- a/src/launch/linux/mod.rs
+++ b/src/launch/linux/mod.rs
@@ -3,3 +3,4 @@
 //! Operations for launching on Linux
 
 pub mod ioctl;
+pub(crate) mod kvm;

--- a/src/launch/mod.rs
+++ b/src/launch/mod.rs
@@ -16,7 +16,7 @@ use super::*;
 use bitflags::bitflags;
 use serde::{Deserialize, Serialize};
 
-use crate::kvm::types::*;
+use crate::launch::linux::kvm::*;
 
 bitflags! {
     /// Configurable SEV Policy options.

--- a/src/launch/sev.rs
+++ b/src/launch/sev.rs
@@ -6,8 +6,8 @@
 
 use super::{Measurement, Secret, Start};
 
-use crate::kvm::types::*;
 use crate::launch::linux::ioctl::*;
+use crate::launch::linux::kvm::*;
 pub use crate::launch::{HeaderFlags, Policy, PolicyFlags};
 
 use std::io::Result;

--- a/src/launch/snp.rs
+++ b/src/launch/snp.rs
@@ -8,8 +8,8 @@ pub use crate::launch::{
     SnpFinish, SnpPageType, SnpPolicy, SnpPolicyFlags, SnpStart, SnpUpdate, VmplPerms,
 };
 
-use crate::kvm::types::*;
 use crate::launch::linux::ioctl::*;
+use crate::launch::linux::kvm::*;
 
 use std::io::Result;
 use std::marker::PhantomData;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@
 
 pub mod certs;
 pub mod firmware;
-pub mod kvm;
 pub mod launch;
 #[cfg(feature = "openssl")]
 pub mod session;


### PR DESCRIPTION
Closes #84 
Replaces #80 
