### PR TITLE
guard linux imports by `target_os`

### DIFF
--- a/src/launch/sev.rs
+++ b/src/launch/sev.rs
@@ -7,6 +7,7 @@
 use super::{Measurement, Secret, Start};
 
 use crate::kvm::types::*;
+#[cfg(target_os = "linux")]
 use crate::launch::linux::ioctl::*;
 pub use crate::launch::{HeaderFlags, Policy, PolicyFlags};
 

--- a/src/launch/snp.rs
+++ b/src/launch/snp.rs
@@ -9,6 +9,7 @@ pub use crate::launch::{
 };
 
 use crate::kvm::types::*;
+#[cfg(target_os = "linux")]
 use crate::launch::linux::ioctl::*;
 
 use std::io::Result;


### PR DESCRIPTION
Guard linux imports by `target_os`, just as it's done here already https://github.com/enarx/sev/blob/3c14b49eb4406984934e76e2f3dd4224e98af7d3/src/launch/mod.rs#L9