### PR TITLE
Add module for SNP guest communication

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,4 +6,8 @@ fn main() {
     if cfg!(feature = "hw_tests") || Path::new("/dev/sev").exists() {
         println!("cargo:rustc-cfg=has_sev");
     }
+
+    if cfg!(feature = "hw_tests") || Path::new("/dev/sev-guest").exists() {
+        println!("cargo:rustc-cfg=has_sev_guest");
+    }
 }

--- a/src/firmware/linux/mod.rs
+++ b/src/firmware/linux/mod.rs
@@ -16,6 +16,9 @@ use types::*;
 /// A handle to the SEV platform.
 pub struct Firmware(File);
 
+/// A handle to the SEV guest platform.
+pub struct GuestFirmware(File);
+
 impl Firmware {
     /// Create a handle to the SEV platform.
     pub fn open() -> std::io::Result<Firmware> {
@@ -149,6 +152,36 @@ impl Firmware {
 }
 
 impl AsRawFd for Firmware {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}
+
+impl GuestFirmware {
+    /// Create a handle to the SEV platform.
+    pub fn open() -> std::io::Result<GuestFirmware> {
+        Ok(GuestFirmware(
+            OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open("/dev/sev-guest")?,
+        ))
+    }
+
+    /// Get the attestation report.
+    pub fn get_report(
+        &mut self,
+        req: SnpGuestReqInput,
+    ) -> Result<SnpGetReport, Indeterminate<Error>> {
+        let mut info = SnpGetReport::default();
+
+        SNP_GET_REPORT.ioctl(&mut self.0, &mut GuestRequest::from(&mut info, &req))?;
+
+        Ok(info)
+    }
+}
+
+impl AsRawFd for GuestFirmware {
     fn as_raw_fd(&self) -> RawFd {
         self.0.as_raw_fd()
     }

--- a/src/firmware/mod.rs
+++ b/src/firmware/mod.rs
@@ -13,8 +13,7 @@ use std::fmt::Debug;
 use std::{error, io};
 
 #[cfg(target_os = "linux")]
-pub use linux::Firmware;
-
+pub use linux::{Firmware, GuestFirmware};
 pub use types::{PlatformStatusFlags, TcbVersion};
 
 /// There are a number of error conditions that can occur between this
@@ -334,4 +333,14 @@ pub struct SnpStatus {
 
     /// TCB status.
     pub tcb: SnpTcbStatus,
+}
+
+/// MISSING_DOC
+#[repr(C)]
+pub struct SnpGuestReqInput {
+    /// MISSING_DOC
+    pub msg_version: u8,
+
+    /// MISSING_DOC
+    pub user_data: [u8; 64],
 }

--- a/src/firmware/types.rs
+++ b/src/firmware/types.rs
@@ -202,3 +202,56 @@ pub struct SnpPlatformStatus {
     /// Reported TCB version.
     pub reported_tcb_version: TcbVersion,
 }
+
+/// SNP guest attestation report data.
+#[derive(Debug)]
+#[repr(C)]
+pub struct SnpGetReport {
+    pub version: u32,
+    pub guest_svn: u32,
+    pub policy: u64,
+    pub family_id: [u8; 16],
+    pub image_id: [u8; 16],
+    pub vmpl: u32,
+    pub sig_algo: u32,
+    pub plat_version: u64,
+    pub plat_info: u64,
+    pub rsvd1: u32,
+    pub report_data: [u8; 64],
+    pub measurement: [u8; 48],
+    pub host_data: [u8; 32],
+    pub id_key_digest: [u8; 48],
+    pub author_key_digest: [u8; 48],
+    pub report_id: [u8; 32],
+    pub report_id_ma: [u8; 32],
+    pub reported_tcb: u64,
+    pub rsvd2: [u8; 72],
+    pub chip_id: [u8; 64],
+}
+
+impl Default for SnpGetReport {
+    fn default() -> Self {
+        Self {
+            version: 0,
+            guest_svn: 0,
+            policy: 0,
+            family_id: [0; 16],
+            image_id: [0; 16],
+            vmpl: 0,
+            sig_algo: 0,
+            plat_version: 0,
+            plat_info: 0,
+            rsvd1: 0,
+            report_data: [0; 64],
+            measurement: [0; 48],
+            host_data: [0; 32],
+            id_key_digest: [0; 48],
+            author_key_digest: [0; 48],
+            report_id: [0; 32],
+            report_id_ma: [0; 32],
+            reported_tcb: 0,
+            rsvd2: [0; 72],
+            chip_id: [0; 64],
+        }
+    }
+}

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sev::cached_chain;
-use sev::{certs::sev::Usage, firmware::Firmware, Build, Version};
+use sev::firmware::{Firmware, GuestFirmware, SnpGuestReqInput};
+use sev::{certs::sev::Usage, Build, Version};
 
 use serial_test::serial;
 
@@ -154,4 +155,18 @@ fn snp_platform_status() {
         status.tcb.reported_version.bootloader,
         status.state
     );
+}
+
+#[cfg_attr(not(has_sev_guest), ignore)]
+#[test]
+fn snp_guest_get_report() {
+    let mut fw = GuestFirmware::open().unwrap();
+    let req = SnpGuestReqInput {
+        msg_version: 1,
+        user_data: [0; 64],
+    };
+
+    let info = fw.get_report(req).unwrap();
+
+    println!("\n\n{:?}\n\n", info);
 }


### PR DESCRIPTION
This is still a WIP. I'm just looking to gain some thoughts on the `sev` crate's ability to be used by SEV-enabled guests rather than being strictly a host-side library. In this case, a guest can now communicate with `/dev/sev-guest` to get an attestation report.

Some work still to be done:
1) Split the `firmware` module into `firmware::host` for the host commands and `firmware::guest` for the guest commands.
2) Build structs from the data returned from `SnpReport` (i.e. the returned `u64` value "policy" should be formatted to a `Policy` struct)
3) Remove the `Id` trait requirement for `GuestRequest`s, as those don't really require an `Id` like the host-side `Command` does.
4) Implement `SNP_GET_DERIVED_KEY`
