### PR TITLE
launch/sev: Derive policy struct from u32

### DIFF
--- a/src/launch/sev.rs
+++ b/src/launch/sev.rs
@@ -176,6 +176,18 @@ pub struct Policy {
     pub minfw: Version,
 }
 
+/// Convert a policy represented as a u32 to a Policy struct.
+impl From<u32> for Policy {
+    fn from(p: u32) -> Self {
+        let flags = PolicyFlags::from_bits_truncate(((p & 0xFF00) >> 8) as u16);
+
+        let minfw = (p & 0xFF) as u16;
+        let minfw: Version = minfw.into();
+
+        Self { flags, minfw }
+    }
+}
+
 /// A secure channel between the tenant and the AMD Secure
 /// Processor.
 #[repr(C)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,15 @@ impl std::fmt::Display for Version {
     }
 }
 
+impl From<u16> for Version {
+    fn from(v: u16) -> Self {
+        Self {
+            major: ((v & 0xF0) >> 4) as u8,
+            minor: (v & 0x0F) as u8,
+        }
+    }
+}
+
 /// A description of the SEV platform's build information.
 #[repr(C)]
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]


### PR DESCRIPTION
QEMU/libvirt represent launch policies as simple unsigned
ints. For better interoperability, allow for the conversion
of u32 to Policy structs.

Signed-off-by: Tyler Fanelli <tfanelli@redhat.com>