### PR TITLE
sesssion: allow TIK and TEK keys to be encoded on their own

### DIFF
--- a/src/session/key.rs
+++ b/src/session/key.rs
@@ -34,6 +34,15 @@ impl DerefMut for Key {
     }
 }
 
+impl codicon::Encoder<()> for Key {
+    type Error = Error;
+    fn encode(&self, mut writer: impl Write, _: ()) -> std::io::Result<()> {
+        writer.write_all(&self.0)?;
+
+        Ok(())
+    }
+}
+
 impl Key {
     pub fn new(key: Vec<u8>) -> Self {
         Self(key)

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -24,8 +24,13 @@ pub struct Verified(launch::sev::Measurement);
 /// This is required for facilitating an SEV launch and attestation.
 pub struct Session<T> {
     policy: launch::sev::Policy,
-    tek: key::Key,
-    tik: key::Key,
+
+    /// Transport Encryption Key.
+    pub tek: key::Key,
+
+    /// Transport Integrity Key.
+    pub tik: key::Key,
+
     data: T,
 }
 


### PR DESCRIPTION
Useful for QEMU/libvirt interoperability

Signed-off-by: Tyler Fanelli <tfanelli@redhat.com>
